### PR TITLE
Allow strings to be passed for the extend and exclude options.

### DIFF
--- a/forecastiopy/ForecastIO.py
+++ b/forecastiopy/ForecastIO.py
@@ -108,16 +108,22 @@ class ForecastIO(object):
         url += '&lang=' + self.lang_url.strip()
         if self.exclude_url is not None:
             excludes = ''
-            for item in self.exclude_url:
-                if item in self._allowed_excludes_extends:
-                    excludes += item + ','
+            if self.exclude_url in self._allowed_excludes_extends:
+                excludes += self.exclude_url + ','
+            else:
+                for item in self.exclude_url:
+                    if item in self._allowed_excludes_extends:
+                        excludes += item + ','
             if len(excludes) > 0:
                 url += '&exclude=' + excludes.rstrip(',')
         if self.extend_url is not None:
             extends = ''
-            for item in self.extend_url:
-                if item in self._allowed_excludes_extends:
-                    extends += item + ','
+            if self.extend_url in self._allowed_excludes_extends:
+                extends += self.extend_url + ','
+            else:
+                for item in self.extend_url:
+                    if item in self._allowed_excludes_extends:
+                        extends += item + ','
             if len(extends) > 0:
                 url += '&extend=' + extends.rstrip(',')
         return url


### PR DESCRIPTION
The previous functionality was the following.

```python
Lisbon = [38.7252993, -9.1500364]
from forecastiopy import *
fio_n = ForecastIO.ForecastIO(YOUR_APY_KEY, latitude=Lisbon[0], longitude=Lisbon[1])
fio_e_l = ForecastIO.ForecastIO(YOUR_APY_KEY, latitude=Lisbon[0], longitude=Lisbon[1], extend=['hourly'])
fio_e_s = ForecastIO.ForecastIO(YOUR_APY_KEY, latitude=Lisbon[0], longitude=Lisbon[1], extend='hourly')
hourly_n = FIOHourly.FIOHourly(fio_n)
hourly_e_l = FIOHourly.FIOHourly(fio_e_l)
hourly_e_s = FIOHourly.FIOHourly(fio_e_s)
```

The number of hours obtained being
```python
>>> hourly_n.hours()
49
>>> hourly_e_l.hours()
169
>>> hourly_e_s.hours()
49
```

I think a user would expect to be able to pass strings as options to the `extend` and `exclude` options.

This pull request allows for this.